### PR TITLE
feat: 添加组件页面中组件所依赖的MIP组件提示

### DIFF
--- a/src/base/inc/scripts.html
+++ b/src/base/inc/scripts.html
@@ -1,7 +1,7 @@
 <script src="https://mipcache.bdstatic.com/static/v1/mip.js"></script>
 
-{{if extensions}}
+{{if extensions && extensions.length}}
     {{each extensions}}
-        <script src="https://mipcache.bdstatic.com/static/v1/{{$value}}/{{$value}}.js"></script>
+        {{@$value}}
     {{/each}}
 {{/if}}

--- a/src/www/components.html
+++ b/src/www/components.html
@@ -12,12 +12,25 @@
                     {{each $value.components val}}
                         <ul>
                             <li><mip-iframe height="{{ val.iframe.height }}" width="100" src="/html/{{ val.iframe.url }}" layout="fixed-height"></mip-iframe></li>
+                            {{ set ext = $imports.getComponentsExtensions(val.iframe.url) }}
+                            {{if ext && ext.length}}
+                                <li>
+                                    依赖组件代码：
+                                </li>
+                                <li>
+                                    {{each ext text}}
+                                        <pre><code>{{text}}</code></pre>
+                                    {{/each}}
+                                </li>
+                            {{/if}}
+
+
                             {{ set code = $imports.getComponentsCode(val.iframe.url) }}
                             {{if code}}
-                            <li>代码：</li>
-                            <li>
-                                {{@ code }}
-                            </li>
+                                <li>代码：</li>
+                                <li>
+                                    {{@ code }}
+                                </li>
                             {{/if}}
                         </ul>
                     {{/each}}

--- a/tools/art-template.js
+++ b/tools/art-template.js
@@ -17,6 +17,23 @@ const PluginError = gutil.PluginError;
 artTemplate.defaults.extname = '.html';
 artTemplate.defaults.minimize = false;
 
+/**
+ * 注入根据预览链接获取组件配置里的 extensions
+ *
+ * @param {string} value 预览链接，以 src 为基础路径
+ * @return {string}
+ */
+artTemplate.defaults.imports.getComponentsExtensions = value => {
+    const filepath = path.resolve(__dirname, '../src/', value.replace('.html', '.json'));
+    return util.getExtensionsUrl(util.mergeJSON(filepath).extensions);
+};
+
+/**
+ * 注入根据预览的链接获取对应的 *.code.html 预览代码
+ *
+ * @param {string} value 预览链接，以 src 为基础路径
+ * @return {string}
+ */
 artTemplate.defaults.imports.getComponentsCode = value => {
     const filepath = path.resolve(__dirname, '../src/', value.replace('.html', '.code.html'));
     const content = util.readFileSync(filepath);

--- a/tools/pre-processor.js
+++ b/tools/pre-processor.js
@@ -26,21 +26,11 @@ module.exports = (filepath, type) => {
 
     // 处理默认数据
     json = Object.assign({
-        page: {},
-        extensions: []
+        page: {}
     }, json);
 
     // 处理组件依赖
-    // 如果是官方内置组件，则不输出
-    if (json.extensions) {
-        if (!Array.isArray(json.extensions)) {
-            json.extensions = [json.extensions];
-        }
-        json.extensions = json.extensions.filter(name => util.coreExtensions.indexOf(name) === -1);
-        if (!json.extensions.length) {
-            json.extensions = null;
-        }
-    }
+    json.extensions = util.getExtensionsUrl(json.extensions);
 
     if (!cssSource) {
         return json;

--- a/tools/util.js
+++ b/tools/util.js
@@ -109,6 +109,24 @@ exports.getFolders = dir => {
 };
 
 /**
+ * 获取组件链接
+ *
+ * @param {Array} arr 组件名数组
+ * @return {Array}
+ */
+exports.getExtensionsUrl = arr => {
+    if (!arr || !arr.length) {
+        return [];
+    }
+    if (!Array.isArray(arr)) {
+        arr = [arr];
+    }
+    return arr
+        .filter(name => exports.coreExtensions.indexOf(name) === -1)
+        .map(name => `<script src="https://mipcache.bdstatic.com/static/v1/${name}/${name}.js"></script>`);
+};
+
+/**
  * 递归合并 JSON 配置文件
  *
  * @param {string} filepath 文件路径


### PR DESCRIPTION
因为基础的UI组件，直接集成了 mag-design 样式，但会有一些复杂交互的组件，这些组件需要依赖 mag-design 样式和MIP组件JS才行运行，我这里大概把功能实现了，具体UI样式还得UE定。

效果如：

![image](https://user-images.githubusercontent.com/3872051/33872884-b4b9cc1c-df53-11e7-91e6-bfa79ec5377b.png)
