### PR TITLE
feat: 添加页面统计功能

### DIFF
--- a/src/www/_inc/baidu-stats.html
+++ b/src/www/_inc/baidu-stats.html
@@ -1,0 +1,1 @@
+<mip-stats-baidu token="4e397f684261b9e4ff9d8ad4714f5b2b"></mip-stats-baidu>

--- a/src/www/_inc/common.json
+++ b/src/www/_inc/common.json
@@ -1,0 +1,8 @@
+{
+    "extend": [
+        "./nav.json"
+    ],
+    "extensions": [
+        "mip-stats-baidu"
+    ]
+}

--- a/src/www/_inc/common.styl
+++ b/src/www/_inc/common.styl
@@ -1,0 +1,2 @@
+@import './nav.styl'
+@import './footer.styl'

--- a/src/www/_inc/layout.html
+++ b/src/www/_inc/layout.html
@@ -8,4 +8,5 @@
 
 {{block 'footer'}}
     {{include './footer.html'}}
+    {{include './baidu-stats.html'}}
 {{/block}}

--- a/src/www/about.json
+++ b/src/www/about.json
@@ -1,6 +1,6 @@
 {
     "extend": [
-        "./_inc/nav.json"
+        "./_inc/common.json"
     ],
     "page": {
         "title": "关于"

--- a/src/www/about.styl
+++ b/src/www/about.styl
@@ -1,2 +1,1 @@
-@import './_inc/nav.styl'
-@import './_inc/footer.styl'
+@import './_inc/common.styl'

--- a/src/www/components.json
+++ b/src/www/components.json
@@ -1,6 +1,6 @@
 {
     "extend": [
-        "./_inc/nav.json"
+        "./_inc/common.json"
     ],
     "page": {
         "title": "组件"

--- a/src/www/components.styl
+++ b/src/www/components.styl
@@ -1,5 +1,4 @@
-@import './_inc/nav.styl'
-@import './_inc/footer.styl'
+@import './_inc/common.styl'
 
 
 .components

--- a/src/www/index.json
+++ b/src/www/index.json
@@ -1,6 +1,6 @@
 {
     "extend": [
-        "./_inc/nav.json"
+        "./_inc/common.json"
     ],
     "page": {
         "title": "主页"

--- a/src/www/index.styl
+++ b/src/www/index.styl
@@ -1,2 +1,1 @@
-@import './_inc/nav.styl'
-@import './_inc/footer.styl'
+@import './_inc/common.styl'

--- a/src/www/templates.html
+++ b/src/www/templates.html
@@ -17,9 +17,9 @@
                                 <mip-img src="/html/{{ $val.img }}" width="200" height="300"></mip-img>
                             </li>
                             <li>
-                                <a href="/html/{{ $val.url }}" data-type="mip" target="_blank">预览</a>
+                                <a data-stats-baidu-obj="{{ $imports.getBaiduStatsEvent('click', 'tpl', 'preview', $val.name) }}" href="/html/{{ $val.url }}" data-type="mip" target="_blank">预览</a>
                             </li>
-                            <li><a href="/archive/{{ $val.name }}.zip">下载</a></li>
+                            <li><a data-stats-baidu-obj="{{ $imports.getBaiduStatsEvent('click', 'tpl', 'down', $val.name) }}" href="/archive/{{ $val.name }}.zip">下载</a></li>
                         </ul>
                     {{/each}}
                 </dd>

--- a/src/www/templates.json
+++ b/src/www/templates.json
@@ -1,6 +1,6 @@
 {
     "extend": [
-        "./_inc/nav.json"
+        "./_inc/common.json"
     ],
     "page": {
         "title": "模板"

--- a/src/www/templates.styl
+++ b/src/www/templates.styl
@@ -1,5 +1,4 @@
-@import './_inc/nav.styl'
-@import './_inc/footer.styl'
+@import './_inc/common.styl'
 
 .templates
     max-width 1000px

--- a/tools/art-template.js
+++ b/tools/art-template.js
@@ -18,9 +18,10 @@ artTemplate.defaults.extname = '.html';
 artTemplate.defaults.minimize = false;
 
 /**
- * 注入模板内获取
+ * 注入模板内获取百度统计事件数据
  *
- * @param {string} value 预览链接，以 src 为基础路径
+ * @param {string} type 事件名称
+ * @param {string} args 事件数据
  * @return {string}
  */
 artTemplate.defaults.imports.getBaiduStatsEvent = function (type) {

--- a/tools/art-template.js
+++ b/tools/art-template.js
@@ -18,6 +18,22 @@ artTemplate.defaults.extname = '.html';
 artTemplate.defaults.minimize = false;
 
 /**
+ * 注入模板内获取
+ *
+ * @param {string} value 预览链接，以 src 为基础路径
+ * @return {string}
+ */
+artTemplate.defaults.imports.getBaiduStatsEvent = function (type) {
+    var args = [].slice.call(arguments);
+    var res = {
+        type: type,
+        data: '[_trackEvent, ' + args.join(',') + ']'
+    };
+    // {"type":"click","data":"[_trackEvent, tpl, down, 1]"}
+    return encodeURIComponent(JSON.stringify(res));
+};
+
+/**
  * 注入根据预览链接获取组件配置里的 extensions
  *
  * @param {string} value 预览链接，以 src 为基础路径


### PR DESCRIPTION
1. 支持下载、预览功能的统计数，使用 [mip-stats-baidu](https://www.mipengine.org/examples/mip-extensions/mip-stats-baidu.html) 组件
1. 优化官网目录结构