### PR TITLE
feat: 添加线上运行环境支持

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@
     - [在官网展示](#showcase)
 - [提交信息规范](#commit-message-spec)
 - [提交请求（pull request）](#pull-request)
+- [线上运行环境](#online)
 
 <a id="issue"></a>
 ## 问题反馈
@@ -225,10 +226,29 @@ git commit 信息和 pull request 标题必须遵循 MIP 项目的 [提交信息
 
 
 <a id="pull-request"></a>
-### 提交请求（pull request）
+## 提交请求（pull request）
 
 1. fork [mipengine/page-design](https://github.com/mipengine/page-design) 。
 1. 把个人仓库（repository）克隆到电脑上，并安装所依赖的插件（ `npm install` ）。
 1. 开始开发，使用 `npm run dev` 命令开发预览，开发完成后，需要运行 `npm run validator` 确认检查 MIP HTML 规范通过。
 1. 推送（push）分支。
 1. 建立一个新的合并申请（pull request）并描述变动。
+
+<a id="online"></a>
+## 线上运行环境
+
+由于有后端接口服务，线上运行依赖 [nodejs](https://nodejs.org/) 版本4+ 。
+
+```bash
+# 编译产出线上运行文件 dist
+npm run build
+
+# 进入目录
+cd dist
+
+# 安装依赖
+npm install
+
+# 运行 nodejs 服务
+npm start
+```

--- a/tools/archive.js
+++ b/tools/archive.js
@@ -14,8 +14,17 @@ const zip = require('gulp-zip');
 const util = require('./util');
 const config = require('./config');
 
+// 顺序是：先copy一份源->清空里面的api->打包->删除copy的
 gulp.task('build:archive', () => {
-    return run('build:archive-before', 'build:archive-task', 'build:archive-after');
+    return run('build:archive-before', 'build:archive-clean-api', 'build:archive-task', 'build:archive-after');
+});
+
+gulp.task('build:archive-clean-api', () => {
+    return gulp.src(config.src.archive + '/**/api', {
+        read: false
+    }).pipe(clean({
+        force: true
+    }));
 });
 
 gulp.task('build:archive-task', () => {

--- a/tools/config.js
+++ b/tools/config.js
@@ -9,7 +9,7 @@ module.exports = {
     src: {
         path: '../src',
         match: '../src/**/*',
-        api: process.env.NODE_ENV === 'development' ? '../src/**/api/**/*.{json,js}' : '../src/**/api/**/*.json',
+        api: '../src/**/api/**/*.{json,js}',
         templates: [
             '../src/templates/*/*.html',
             '!../**/*/_*',

--- a/tools/gulpfile.js
+++ b/tools/gulpfile.js
@@ -21,7 +21,10 @@ require('./html-minifier');
 require('./archive');
 require('./validate');
 require('./format');
+require('./publish');
 
+// 开发流程：
+// 编译模板、组件、官网、启动 webserver 、启动监听服务
 gulp.task('dev', ['build:templates', 'build:components', 'build:www', 'webserver'], () => {
     gulp.watch(['../src/templates/**/*', '../src/base/**/*'], ['build:templates']);
     gulp.watch(['../src/components/**/*', '../src/base/**/*'], ['build:components']);
@@ -40,6 +43,11 @@ gulp.task('dev', ['build:templates', 'build:components', 'build:www', 'webserver
 });
 /* eslint-enable no-console */
 
+// 验证流程：
+// 1. 清空 dist 目录
+// 2. 编译模板、组件、官网到 dist 下，验证产出代码是否符合 MIP HTML 规范
+// 3. 复制一份 dist 代码到 .archive 并压缩代码到 dist 下，并验证产出代码是否符合 MIP HTML 规范
+// 4. 删除产出的 .archive
 gulp.task('validator', () => {
     const task = [];
 
@@ -57,6 +65,11 @@ gulp.task('validator', () => {
     return run.apply(run, task);
 });
 
+// 打包流程：
+// 1. 清空 dist 目录
+// 2. 编译模板、组件、官网到 dist 下，验证产出代码是否符合 MIP HTML 规范
+// 3. 复制一份 dist 代码到 .archive 并压缩代码到 dist 下，并验证产出代码是否符合 MIP HTML 规范
+// 4. 把 .archive 打包到 dist/archive 下
 gulp.task('build', () => {
     const task = [];
 
@@ -71,6 +84,9 @@ gulp.task('build', () => {
 
     // 打 zip 包
     task.push('build:archive');
+
+    // 线上运行环境
+    task.push('publish');
 
     return run.apply(run, task);
 });

--- a/tools/publish.js
+++ b/tools/publish.js
@@ -1,0 +1,28 @@
+/**
+ * @file 复制线上运行文件
+ * @author mip-support@baidu.com
+ */
+
+'use strict';
+
+const gulp = require('gulp');
+const path = require('path');
+const fs = require('fs');
+
+gulp.task('publish', () => {
+    const pkg = require('../package.json');
+    delete pkg.devDependencies;
+    delete pkg.config;
+    pkg.dependencies = {
+        'express': '*',
+        'express-api-require': '*',
+        'res-json': '*'
+    };
+    pkg.scripts = {
+        start: 'node server.js'
+    };
+    fs.writeFileSync(path.resolve(__dirname, '../dist/package.json'), JSON.stringify(pkg, null, 2));
+
+    const server = fs.readFileSync(path.resolve(__dirname, './server.js')).toString();
+    fs.writeFileSync(path.resolve(__dirname, '../dist/server.js'), server);
+});

--- a/tools/server.js
+++ b/tools/server.js
@@ -1,0 +1,24 @@
+/**
+ * @file 线上运行环境，支持 API 中间件调用
+ * @author mip-support@baidu.com
+ */
+
+'use strict';
+
+const json = require('res-json');
+const express = require('express');
+const app = express();
+const api = require('express-api-require');
+
+// 注入 res.json, res.jsonp 方法
+app.use(json());
+
+// 注入
+app.use(api({
+    root: __dirname
+}));
+
+// 托管静态文件
+app.use(express.static('./'));
+
+app.listen(8080, () => console.log('mipgo app listening on port 8080!'));


### PR DESCRIPTION
由于 MIPGO 需要支持异步接口，单纯的静态 server 不能满足，为了支持 JSON 和更广泛的中间件形式，使用 nodejs 作为后端运行环境。

在 `npm run build` 时会把线上依赖的几个模块写入到 `package.json` 中，并把线上运行的 `server.js` 复制到 dist 目录，安装依赖后既可运行。